### PR TITLE
Fix loading of non-existent github-token.txt

### DIFF
--- a/lib/META6/bin.pm6
+++ b/lib/META6/bin.pm6
@@ -40,12 +40,12 @@ my &RED = sub (*@s) {
 
 &BOLD = &RED = sub (Stringy $s) { $s } unless $*OUT.t;
 
-my @path = "%*ENV<HOME>/.meta6"».IO;
-my $cfg-dir = %*ENV<HOME>.IO.child('.meta6');
+my $cfg-dir = $*HOME.child('.meta6');
+my @path = $cfg-dir;
 my $github-user = git-config<credential><username>;
 my $github-realname = git-config<user><name>;
 my $github-email = git-config<user><email>;
-my $github-token = $cfg-dir.?child('github-token.txt').?slurp.chomp // '';
+my $github-token = chomp $cfg-dir.child('github-token.txt').slurp // '';
 
 if $cfg-dir.e & !$cfg-dir.d {
     note "WARN: ⟨$cfg-dir⟩ is not a directory.";


### PR DESCRIPTION
The code still explodes, since IO::Path *does* have the slurp method, so it still fails when trying to read non-existent file.

Also change `%*ENV<HOME> to `$*HOME` that uses `%*ENV<HOME>` if set, but also Does The Right thing on Windows as well.

P.S.: the test run still fails on HEAD rakudo, but that's likely to a Rakudo's issue that'll be fixed shortly