### PR TITLE
Use Artistic-2.0 as license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -34,7 +34,7 @@
   "tags": [
     
   ],
-  "license": "Artistic 2.0",
+  "license": "Artistic-2.0",
   "test-depends": [
     
   ],


### PR DESCRIPTION
This is the SPDX license identifier as specced for the
META6.json: https://design.perl6.org/S22.html#license